### PR TITLE
Sec-WebSocket-Key gets truncated when it's the last header in the http request

### DIFF
--- a/src/6455.fs
+++ b/src/6455.fs
@@ -15,7 +15,7 @@ module RFC6455 =
 
     let getLines (bytes: Byte []) len =
         if len > 8 then
-            bytes.[..(len - 9)]
+            bytes.[..(len)]
             |> UTF8Encoding.UTF8.GetString
             |> fun hs -> hs.Split([| "\r\n" |], StringSplitOptions.RemoveEmptyEntries)
         else


### PR DESCRIPTION
I removed the ` - 9` that truncated the last header of the HTTP request. This is an issue when the Sec-WebSocket-Key is in the last position. Because the Sec-WebSocket-Accept code becomes invalid for the client.

I don't know how important removing those 9 bytes, so this is more a proposition. But it solves issue #4.

Tested with [websocat](https://github.com/vi/websocat) and [wscat](https://www.npmjs.com/package/wscat).
```
websocat ws://0.0.0.0:1900/echo
wscat --connect ws://0.0.0.0:1900/echo
```
websocat default to set the Sec-WebSocket-Key header last.